### PR TITLE
Replace deprecated class, no longer available in Pharo 10

### DIFF
--- a/Porpoise-Core/Utf8String.class.st
+++ b/Porpoise-Core/Utf8String.class.st
@@ -7,5 +7,5 @@ Class {
 { #category : #'instance creation' }
 Utf8String class >> fromByteArray: aByteArray [
 
-	^UTF8TextConverter default convertFromSystemString: aByteArray asString
+	^^ZnUTF8Encoder default decodeBytes: aByteArray
 ]


### PR DESCRIPTION
Replacement class is available from at least Pharo 6.1