### PR TITLE
Fix double ^

### DIFF
--- a/Porpoise-Core/Utf8String.class.st
+++ b/Porpoise-Core/Utf8String.class.st
@@ -7,5 +7,5 @@ Class {
 { #category : #'instance creation' }
 Utf8String class >> fromByteArray: aByteArray [
 
-	^^ZnUTF8Encoder default decodeBytes: aByteArray
+	^ZnUTF8Encoder default decodeBytes: aByteArray
 ]


### PR DESCRIPTION

Had trouble installing via Metacello, I think it was the double `^` character here.