### PR TITLE
Make LookupTable and WeakLookupTable aliases rather than empty subclasses

### DIFF
--- a/Porpoise-Core/LookupTable.class.st
+++ b/Porpoise-Core/LookupTable.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #LookupTable,
-	#superclass : #Dictionary,
-	#category : #'Porpoise-Core'
-}

--- a/Porpoise-Core/PorpoiseCore.class.st
+++ b/Porpoise-Core/PorpoiseCore.class.st
@@ -5,15 +5,16 @@ Class {
 }
 
 { #category : #'class initialization' }
-PorpoiseCore class >> initialize [ 
-
+PorpoiseCore class >> initialize [
 	"Create class pseudonyms
 	
 	self initialize 
 	
 	"
 
-	self environment 
+	self environment
 		at: #AnsiString put: ByteString;
-		at: #ArithmeticValue put: Number
+		at: #ArithmeticValue put: Number;
+		at: #LookupTable put: Dictionary;
+		at: #WeakLookupTable put: WeakValueDictionary
 ]

--- a/Porpoise-Core/WeakLookupTable.class.st
+++ b/Porpoise-Core/WeakLookupTable.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #WeakLookupTable,
-	#superclass : #WeakValueDictionary,
-	#category : #'Porpoise-Core'
-}


### PR DESCRIPTION
Fixes LookupTable not equal to Dictionary with same contents (as they're compared by #species as well--could implement that instead, but why bother when there's no actual difference?)