### PR TITLE
Register ExternalHandle in "system" category in the startup list

### DIFF
--- a/Porpoise-FFI/ExternalHandle.class.st
+++ b/Porpoise-FFI/ExternalHandle.class.st
@@ -11,7 +11,7 @@ ExternalHandle class >> initialize [
 	self initialize
 	"
 
-	Smalltalk addToStartUpList: self
+	SessionManager current registerSystemClassNamed: self name
 ]
 
 { #category : #'system startup' }


### PR DESCRIPTION
Causes them to be invalidated sooner, before any user code runs that might tear down higher-level resources and try to free a handle that is already invalid.

See corresponding Pharo-ODBC pull request—that's where I had the issue, but this obviously _could_ come up with any ExternalHandle, and I believe in Dolphin they are already null when the interpreter begins execution, having been cleared by the VM itself while reading the image, so it should be done as early as practical in Pharo.