### PR TITLE
#newFixed: can be an alias for #newPinned:

### DIFF
--- a/Porpoise-FFI/Behavior.extension.st
+++ b/Porpoise-FFI/Behavior.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Porpoise-FFI' }
+Behavior >> newFixed: anInteger [
+
+	^ self newPinned: anInteger
+]

--- a/Porpoise-FFI/ByteArray.extension.st
+++ b/Porpoise-FFI/ByteArray.extension.st
@@ -9,11 +9,6 @@ ByteArray >> copyBytesTo: aFFIStructure [
 ]
 
 { #category : #'*Porpoise-FFI' }
-ByteArray class >> newFixed: anInteger [ 
-	^ExternalByteArray newFixed: anInteger
-]
-
-{ #category : #'*Porpoise-FFI' }
 ByteArray >> replaceBytesOf: aString from: start to: stop startingAt: anInteger [ 
 
 	^aString replaceFrom: start to: stop with: self startingAt: anInteger

--- a/Porpoise-FFI/String.extension.st
+++ b/Porpoise-FFI/String.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #String }
-
-{ #category : #'*Porpoise-FFI' }
-String class >> newFixed: anInteger [
-
-	^self new: anInteger
-]


### PR DESCRIPTION
This is much more similar to what Dolphin #newFixed: does--a regular Smalltalk object that cannot move during garbage collection.

This leaves `ExternalByteArray` hanging a bit, nobody uses it anymore. And Utf16String is a useful concept but could/should really be implemented _on top of_ a pinned ByteArray, rather than as a subclass of ExternalByteArray. But those are separate things.